### PR TITLE
fix: Update bucket policies for April 2023 S3 security policy changes.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -125,7 +125,7 @@ resource "aws_s3_bucket" "vantage_cost_and_usage_reports" {
 }
 
 resource "aws_s3_bucket_acl" "vantage_cost_and_usage_reports" {
-  count  = var.cur_bucket_name != "" ? 1 : 0
+  count  = var.compatibility_private_bucket_acl ? 1 : 0
   bucket = aws_s3_bucket.vantage_cost_and_usage_reports[0].id
   acl    = "private"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -15,3 +15,9 @@ variable "cur_report_name" {
   description = "Report name for the CUR report definition."
   default     = "VantageReport"
 }
+
+variable "compatibility_private_bucket_acl" {
+  type        = bool
+  description = "For backwards compatibility, users can set this variable to true so a 'private' bucket ACL is applied. This is not necessary for new buckets being created. If you're unsure, leave this as false."
+  default     = false
+}


### PR DESCRIPTION
Once merged, will publish as tag `0.1.0` as the variable can be used for backwards compatibility. Verified new bucket provisioning functions as expected.