### PR TITLE
Allow overriding root AWS IAM policy.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "aws_iam_role" "vantage_cross_account_connection_with_bucket" {
 
   inline_policy {
     name   = "root"
-    policy = data.vantage_aws_provider_info.default.root_policy
+    policy = var.vantage_root_iam_policy_override != null ? var.vantage_root_iam_policy_override : data.vantage_aws_provider_info.default.root_policy
   }
 
   dynamic "inline_policy" {
@@ -57,12 +57,12 @@ resource "aws_iam_role" "vantage_cross_account_connection_with_bucket" {
 
   inline_policy {
     name   = "VantageCloudWatchMetricsReadOnly"
-    policy = data.vantage_aws_provider_info.default.cloudwatch_metrics_policy
+    policy = var.vantage_cloudwatch_metrics_iam_policy_override != null ? var.vantage_cloudwatch_metrics_iam_policy_override : data.vantage_aws_provider_info.default.cloudwatch_metrics_policy
   }
 
   inline_policy {
     name   = "VantageAdditionalResourceReadOnly"
-    policy = data.vantage_aws_provider_info.default.additional_resources_policy
+    policy = var.vantage_additional_resources_iam_policy_override != null ? var.vantage_additional_resources_iam_policy_override : data.vantage_aws_provider_info.default.additional_resources_policy
   }
 }
 
@@ -73,22 +73,25 @@ resource "aws_iam_role" "vantage_cross_account_connection_without_bucket" {
 
   inline_policy {
     name   = "root"
-    policy = data.vantage_aws_provider_info.default.root_policy
+    policy = var.vantage_root_iam_policy_override != null ? var.vantage_root_iam_policy_override : data.vantage_aws_provider_info.default.root_policy
   }
 
-  inline_policy {
-    name   = "VantageAutoPilot"
-    policy = data.vantage_aws_provider_info.default.autopilot_policy
+  dynamic "inline_policy" {
+    for_each = var.enable_autopilot ? [1] : []
+    content {
+      name   = "VantageAutoPilot"
+      policy = data.vantage_aws_provider_info.default.autopilot_policy
+    }
   }
 
   inline_policy {
     name   = "VantageCloudWatchMetricsReadOnly"
-    policy = data.vantage_aws_provider_info.default.cloudwatch_metrics_policy
+    policy = var.vantage_cloudwatch_metrics_iam_policy_override != null ? var.vantage_cloudwatch_metrics_iam_policy_override : data.vantage_aws_provider_info.default.cloudwatch_metrics_policy
   }
 
   inline_policy {
     name   = "VantageAdditionalResourceReadOnly"
-    policy = data.vantage_aws_provider_info.default.additional_resources_policy
+    policy = var.vantage_additional_resources_iam_policy_override != null ? var.vantage_additional_resources_iam_policy_override : data.vantage_aws_provider_info.default.additional_resources_policy
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -27,3 +27,21 @@ variable "enable_autopilot" {
   description = "Enable Vantage Autopilot. This will create more permissions for the cross account role."
   default     = true
 }
+
+variable "vantage_root_iam_policy_override" {
+  type        = string
+  description = "AWS IAM Policy to override the Vantage Root IAM policy."
+  default     = null
+}
+
+variable "vantage_cloudwatch_metrics_iam_policy_override" {
+  type        = string
+  description = "AWS IAM Policy to override the Vantage Cloudwatch Metrics IAM policy."
+  default     = null
+}
+
+variable "vantage_additional_resources_iam_policy_override" {
+  type        = string
+  description = "AWS IAM Policy to override the Vantage Additional ResourcesIAM policy."
+  default     = null
+}


### PR DESCRIPTION
Allow overriding AWS IAM Policies.

```
provider "aws" {
  region = "us-east-1"
  assume_role {
    role_arn = var.aws_assume_role
  }
}

module "vantage-integrations" {
  source = "vantage-sh/vantage-integration/aws"
  vantage_root_iam_policy_override = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Action": [
        "savingsplans:Describe*"
      ],
      "Resource": "*",
      "Effect": "Allow",
      "Sid": "VantageBillingReadOnly"
    }                
  ]
}
EOF
}
```