### PR TITLE
fix: loosen aws version constraints

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4"
+      version = ">= 4.0.0, < 6.0.0"
     }
   }
   required_version = ">= 1.0.0"


### PR DESCRIPTION
Currently this doesn't support aws v5 which has been out for a while. Please expand the version constraints to support v5.