### PR TITLE
Allow tags to be passed into module and set on supported resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,8 @@ resource "aws_iam_role" "vantage_cross_account_connection_with_bucket" {
       policy = inline_policy.value["policy"]
     }
   }
+
+  tags = var.tags
 }
 
 resource "aws_iam_role" "vantage_cross_account_connection_without_bucket" {
@@ -109,6 +111,8 @@ resource "aws_iam_role" "vantage_cross_account_connection_without_bucket" {
       policy = inline_policy.value["policy"]
     }
   }
+
+  tags = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "vantage_cross_account_connection_with_bucket" {
@@ -144,6 +148,8 @@ resource "aws_s3_bucket" "vantage_cost_and_usage_reports" {
   count         = var.cur_bucket_name != "" ? 1 : 0
   bucket        = var.cur_bucket_name
   force_destroy = true
+
+  tags          = var.tags
 }
 
 resource "aws_s3_bucket_acl" "vantage_cost_and_usage_reports" {

--- a/variables.tf
+++ b/variables.tf
@@ -51,3 +51,9 @@ variable "additional_inline_policies" {
   description = "Additonal IAM Policies to include on the cross account role."
   default     = []
 }
+
+variable "tags" {
+  description = "A map of tags to add to all supported resources managed by the module."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Usage example: 

```
module "vantage-integration" {
  source                   = "vantage-sh/vantage-integration/aws"
  version                   = "0.1.3"

  cur_bucket_name = "chime-cur-vantage"
  tags = {
    Team  = "Infra-Engineering"
    Group = "Engineering-Services"
  }
}
```