### PR TITLE
feat: Allow configuring the lifecycle policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -159,14 +159,14 @@ resource "aws_s3_bucket_acl" "vantage_cost_and_usage_reports" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "vantage_cost_and_usage_reports" {
-  count  = var.cur_bucket_name != "" ? 1 : 0
+  count  = var.cur_bucket_name != "" && var.cur_bucket_lifecycle_enabled ? 1 : 0
   bucket = aws_s3_bucket.vantage_cost_and_usage_reports[0].id
 
   rule {
     id = "remove-old-reports"
 
     expiration {
-      days = 200
+      days = var.cur_bucket_lifecycle_days
     }
 
     status = "Enabled"

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,18 @@ variable "cur_bucket_name" {
   default     = ""
 }
 
+variable "cur_bucket_lifecycle_enabled" {
+  type        = bool
+  description = "Enable lifecycle configuration for the CUR bucket."
+  default     = true
+}
+
+variable "cur_bucket_lifecycle_days" {
+  type        = number
+  description = "Number of days to retain CUR reports in the bucket."
+  default     = 200
+}
+
 variable "cur_report_time_unit" {
   description = "The granularity of the cost and usage report: HOURLY or DAILY."
   type        = string
@@ -74,4 +86,3 @@ variable "cur_report_additional_schema_elements" {
   type        = list(string)
   default     = ["RESOURCES"]
 }
-


### PR DESCRIPTION
Currently, the module sets a lifecycle configuration which expires all objects after 200 days, but this value is hard-coded. 

I've added the variable `cur_bucket_lifecycle_days` to make this configurable.

Additionally, the resource `aws_s3_bucket_lifecycle_configuration` has a restriction where [you cannot create multiple instances of that resource per bucket](https://registry.terraform.io/providers/hashicorp/aws/6.0.0-beta3/docs/resources/s3_bucket_lifecycle_configuration). This is a problem if you need to enable bucket versioning for compliance purposes, since you would need to set up a separate lifecycle policy which expires non-current versions. As a result, users can now disable the default policy with `cur_bucket_lifecycle_enabled = false`, allowing them to create their own policy.