### PR TITLE
chore(deps): bump allowed AWS provider version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 6.0.0"
+      version = ">= 4.0.0, < 7.0.0"
     }
   }
   required_version = ">= 1.0.0"

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 7.0.0"
+      version = ">= 4.0.0"
     }
   }
   required_version = ">= 1.0.0"


### PR DESCRIPTION
This bumps the allowed version for the aws provider to allow version 6.0.0 and later to be used, too.

Another possibility would be to completely remove the upper version constraint, but the change in this PR has fewer implications than the complete removal.
Therefore, I decided to propose this initially.

I'm happy to completely remove the upper version constraint if you'd prefer that.
