### PR TITLE
feat(IAM Role): add the possibility to set a permissions boundary

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,8 +34,9 @@ data "aws_iam_policy_document" "vantage_assume_role" {
 resource "aws_iam_role" "vantage_cross_account_connection_with_bucket" {
   count = var.cur_bucket_name != "" ? 1 : 0
 
-  name               = "vantage_cross_account_connection"
-  assume_role_policy = data.aws_iam_policy_document.vantage_assume_role.json
+  name                 = "vantage_cross_account_connection"
+  assume_role_policy   = data.aws_iam_policy_document.vantage_assume_role.json
+  permissions_boundary = var.permissions_boundary_arn
 
   inline_policy {
     name   = "VantageCostandUsageReportRetrieval"
@@ -77,9 +78,10 @@ resource "aws_iam_role" "vantage_cross_account_connection_with_bucket" {
 }
 
 resource "aws_iam_role" "vantage_cross_account_connection_without_bucket" {
-  count              = var.cur_bucket_name != "" ? 0 : 1
-  name               = "vantage_cross_account_connection"
-  assume_role_policy = data.aws_iam_policy_document.vantage_assume_role.json
+  count                = var.cur_bucket_name != "" ? 0 : 1
+  name                 = "vantage_cross_account_connection"
+  assume_role_policy   = data.aws_iam_policy_document.vantage_assume_role.json
+  permissions_boundary = var.permissions_boundary_arn
 
   inline_policy {
     name   = "root"

--- a/variables.tf
+++ b/variables.tf
@@ -86,3 +86,14 @@ variable "cur_report_additional_schema_elements" {
   type        = list(string)
   default     = ["RESOURCES"]
 }
+
+variable "permissions_boundary_arn" {
+  type        = string
+  default     = null
+  description = "The ARN of the IAM policy to use as the permissions boundary for the IAM role. If not set, no permissions boundary will be applied."
+
+  validation {
+    condition     = var.permissions_boundary_arn == null || can(regex("^arn:aws(-[a-z]+)?:iam::\\d{12}:policy/.+", var.permissions_boundary_arn))
+    error_message = "If set, permissions_boundary_arn must be a valid IAM policy ARN."
+  }
+}


### PR DESCRIPTION
This PR will:
- Add a permissions_boundary_arn variable to set a permissions boundary on the IAM roles.
- If you don’t set it, nothing changes.
- Includes validation to make sure the ARN is valid.
- Hooked it to the IAM role(s) in the module.
