### PR TITLE
Update docs to say Vantage provider is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This module handles linking an AWS account with your Vantage account. For root A
 ## Usage
 This module configures an AWS Account integration on Vantage. By default, it does not configure a CUR integration. If the account is your root AWS account and you want to configure a CUR integration, use the `cur_bucket_name` variable to provision that. The bucket name is used for a private S3 bucket and must be globally unique.
 
+Using the module requires the `hashicorp/aws` and `vantage-sh/vantage` providers.
+
 The below examples assumes you'll use the [assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#assuming-an-iam-role) feature of the AWS provider to access the desired AWS account.
 
 ### Management AWS Account with Cost and Usage Reports (CUR) Integration
@@ -16,6 +18,13 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::123456789012:role/admin-role"
   }
+}
+
+provider "vantage" {
+  # A Vantage API Token is needed to use this module, it is recommended to either use env var VANTAGE_API_TOKEN
+  # or to use a tfvars file that's not committed to the repository. Follow the instructions here to create a new
+  # API Token: /vantage_account#create-an-api-token
+  api_token = YOUR_API_TOKEN
 }
 
 module "vantage-integration" {
@@ -38,6 +47,13 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::123456789012:role/admin-role"
   }
+}
+
+provider "vantage" {
+  # A Vantage API Token is needed to use this module, it is recommended to either use env var VANTAGE_API_TOKEN
+  # or to use a tfvars file that's not committed to the repository. Follow the instructions here to create a new
+  # API Token: /vantage_account#create-an-api-token
+  api_token = YOUR_API_TOKEN
 }
 
 module "vantage-integration" {


### PR DESCRIPTION
While the website docs do mention that the vantage provider is required, the Terraform module docs don't mention it.

This is fairly surprising if you attempt to use this module, not realizing that you will need to provide a Vantage API key and run `terraform init` to install the provider.

https://docs.vantage.sh/terraform#vantage-terraform-integrations-module-for-aws