### PR TITLE
chore: update bucket policy to reflect new Data Exports CUR 2.0 permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This module handles linking an AWS account with your Vantage account. For root A
 
 This module configures an AWS Account integration on Vantage. By default, it does not configure a CUR integration. If the account is your root AWS account and you want to configure a CUR integration, use the `cur_bucket_name` variable to provision that. The bucket name is used for a private S3 bucket and must be globally unique.
 
-The below examples assumes you'll use the [assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#assuming-an-iam-role) feature of the AWS provider to access the desired AWS account.
+By default, the bucket is provisioned in the `us-east-1` region. If you want to provision the bucket in a different region, use the `cur_bucket_region` variable.
+
+The below examples assume you'll use the [assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#assuming-an-iam-role) feature of the AWS provider to access the desired AWS account.
 
 ### Management AWS Account with Cost and Usage Reports (CUR) Integration
 

--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,7 @@ resource "aws_cur_report_definition" "vantage_cost_and_usage_reports" {
   compression                = "GZIP"
   additional_schema_elements = var.cur_report_additional_schema_elements
   s3_bucket                  = aws_s3_bucket.vantage_cost_and_usage_reports[0].id
-  s3_region                  = "us-east-1"
+  s3_region                  = var.cur_bucket_region
   s3_prefix                  = "${lower(var.cur_report_time_unit)}-v1"
   report_versioning          = "OVERWRITE_REPORT"
   refresh_closed_reports     = true

--- a/main.tf
+++ b/main.tf
@@ -264,6 +264,10 @@ data "aws_iam_policy_document" "vantage_cur_access" {
     effect    = "Allow"
     actions   = ["s3:PutObject"]
     resources = ["${aws_s3_bucket.vantage_cost_and_usage_reports[0].arn}/*"]
+    principals {
+      type        = "Service"
+      identifiers = ["billingreports.amazonaws.com"]
+    }
     condition {
       test     = "StringEquals"
       variable = "aws:SourceArn"

--- a/main.tf
+++ b/main.tf
@@ -261,7 +261,7 @@ data "aws_iam_policy_document" "vantage_cur_access" {
       variable = "aws:SourceArn"
       values = [
         "arn:aws:cur:us-east-1:${local.account_id}:definition/*",
-        "arn:aws:bcm-data-exports:us-east-1::export/*"
+        "arn:aws:bcm-data-exports:us-east-1:${local.account_id}:export/*"
       ]
     }
 

--- a/main.tf
+++ b/main.tf
@@ -234,28 +234,69 @@ data "aws_iam_policy_document" "vantage_cur_retrieval" {
 data "aws_iam_policy_document" "vantage_cur_access" {
   count = var.cur_bucket_name != "" ? 1 : 0
 
+  # Legacy CUR reports
   statement {
-    sid = "EnableAWSDataExportsToWriteToS3AndCheckPolicy"
+    sid    = "S3BucketPermissionsRetrieval"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["billingreports.amazonaws.com"]
+    }
+    actions = [
+      "s3:GetBucketAcl",
+      "s3:GetBucketPolicy",
+    ]
+    resources = [aws_s3_bucket.vantage_cost_and_usage_reports[0].arn]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:cur:us-east-1:${local.account_id}:definition/*"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [local.account_id]
+    }
+  }
 
+  statement {
+    sid       = "S3PutObject"
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.vantage_cost_and_usage_reports[0].arn}/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:cur:us-east-1:${local.account_id}:definition/*"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [local.account_id]
+    }
+  }
+
+  # CUR 2.0 reports
+  statement {
+    sid    = "EnableAWSDataExportsToWriteToS3AndCheckPolicy"
     effect = "Allow"
 
+    principals {
+      type = "Service"
+      identifiers = [
+        "bcm-data-exports.amazonaws.com",
+        "billingreports.amazonaws.com"
+      ]
+    }
     actions = [
       "s3:PutObject",
       "s3:GetBucketPolicy"
     ]
-    principals {
-      type = "Service"
-      identifiers = [
-        "billingreports.amazonaws.com",
-        "bcm-data-exports.amazonaws.com"
-      ]
-    }
 
     resources = [
       aws_s3_bucket.vantage_cost_and_usage_reports[0].arn,
       "${aws_s3_bucket.vantage_cost_and_usage_reports[0].arn}/*"
     ]
-
     condition {
       test     = "StringLike"
       variable = "aws:SourceArn"
@@ -264,7 +305,6 @@ data "aws_iam_policy_document" "vantage_cur_access" {
         "arn:aws:bcm-data-exports:us-east-1:${local.account_id}:export/*"
       ]
     }
-
     condition {
       test     = "StringLike"
       variable = "aws:SourceAccount"

--- a/main.tf
+++ b/main.tf
@@ -233,57 +233,38 @@ data "aws_iam_policy_document" "vantage_cur_access" {
   count = var.cur_bucket_name != "" ? 1 : 0
 
   statement {
+    sid = "EnableAWSDataExportsToWriteToS3AndCheckPolicy"
+
     effect = "Allow"
 
     actions = [
-      "s3:GetBucketAcl",
+      "s3:PutObject",
       "s3:GetBucketPolicy"
     ]
     principals {
-      type        = "Service"
-      identifiers = ["billingreports.amazonaws.com"]
+      type = "Service"
+      identifiers = [
+        "billingreports.amazonaws.com",
+        "bcm-data-exports.amazonaws.com"
+      ]
     }
 
     resources = [
-      aws_s3_bucket.vantage_cost_and_usage_reports[0].arn
-    ]
-
-    condition {
-      test     = "StringEquals"
-      variable = "aws:SourceArn"
-      values   = ["arn:aws:cur:us-east-1:${local.account_id}:definition/*"]
-    }
-
-    condition {
-      test     = "StringEquals"
-      variable = "aws:SourceAccount"
-      values   = [local.account_id]
-    }
-  }
-
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "s3:PutObject"
-    ]
-    principals {
-      type        = "Service"
-      identifiers = ["billingreports.amazonaws.com"]
-    }
-
-    resources = [
+      aws_s3_bucket.vantage_cost_and_usage_reports[0].arn,
       "${aws_s3_bucket.vantage_cost_and_usage_reports[0].arn}/*"
     ]
 
     condition {
-      test     = "StringEquals"
+      test     = "StringLike"
       variable = "aws:SourceArn"
-      values   = ["arn:aws:cur:us-east-1:${local.account_id}:definition/*"]
+      values = [
+        "arn:aws:cur:us-east-1:${local.account_id}:definition/*",
+        "arn:aws:bcm-data-exports:us-east-1::export/*"
+      ]
     }
 
     condition {
-      test     = "StringEquals"
+      test     = "StringLike"
       variable = "aws:SourceAccount"
       values   = [local.account_id]
     }

--- a/main.tf
+++ b/main.tf
@@ -151,6 +151,7 @@ resource "aws_cur_report_definition" "vantage_cost_and_usage_reports" {
   depends_on = [
     aws_s3_bucket_policy.vantage_cost_and_usage_reports
   ]
+  tags = var.tags
 }
 
 resource "aws_s3_bucket" "vantage_cost_and_usage_reports" {

--- a/main.tf
+++ b/main.tf
@@ -174,6 +174,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "vantage_cost_and_usage_reports
   rule {
     id = "remove-old-reports"
 
+    filter {}
+
     expiration {
       days = var.cur_bucket_lifecycle_days
     }

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "cur_bucket_name" {
   default     = ""
 }
 
+variable "cur_bucket_region" {
+  type        = string
+  description = "The region where the CUR bucket will be created."
+  default     = "us-east-1"
+}
+
 variable "cur_bucket_lifecycle_enabled" {
   type        = bool
   description = "Enable lifecycle configuration for the CUR bucket."


### PR DESCRIPTION
Policy determined by https://docs.aws.amazon.com/cur/latest/userguide/dataexports-s3-bucket.html as well as creating a fresh CUR bucket via the AWS console