### PR TITLE
docs: Add missing note about api key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This module handles linking an AWS account with your Vantage account. For root AWS accounts, you will want to provision a CUR bucket via the `cur_bucket_name` variable. For subaccounts you will want to link access but won't need to configure the CUR bucket.
 
+> **Before you begin:** A Vantage API token with **Write** scope, assigned to the **Everyone** team, is required. See [the Vantage documentation](https://docs.vantage.sh/api/authentication) for information on how to create a token. Set the `VANTAGE_API_TOKEN` environment variable (or configure the provider’s `api_token`) before running Terraform.
+
 ## Usage
 
 This module configures an AWS Account integration on Vantage. By default, it does not configure a CUR integration. If the account is your root AWS account and you want to configure a CUR integration, use the `cur_bucket_name` variable to provision that. The bucket name is used for a private S3 bucket and must be globally unique.


### PR DESCRIPTION
https://linear.app/vantage-sh/issue/DOC-52/document-vantage-api-token-requirement-for-terraform-module

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no Terraform logic, providers, or resources are modified.
> 
> **Overview**
> Adds a **“Before you begin”** note to `README.md` clarifying that a Vantage API token with **Write** scope (assigned to **Everyone**) is required, and that it must be provided via `VANTAGE_API_TOKEN` or the provider’s `api_token` before running Terraform.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a74a86c8dcadee9bf3ef56beb22c2355411b1e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->