### PR TITLE
fix: Remove tag attribute from aws_cur_report_definition resource.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -151,7 +151,6 @@ resource "aws_cur_report_definition" "vantage_cost_and_usage_reports" {
   depends_on = [
     aws_s3_bucket_policy.vantage_cost_and_usage_reports
   ]
-  tags = var.tags
 }
 
 resource "aws_s3_bucket" "vantage_cost_and_usage_reports" {


### PR DESCRIPTION
Tags on aws_cur_report_definition isn't supported until aws provider >= 5.60.0.

Rather than bump the required version of the AWS provider we decided to remove the tag attribute since it's not necessary functionality and matches the Cloudformation approach.

BREAKING CHANGE: if you have been definining tags, this release will remove them from aws_cur_report_definition since they're no longer defined on the resource.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because this is a breaking IaC change: existing CUR report definitions may show a Terraform diff and previously configured tags will no longer be managed on that resource.
> 
> **Overview**
> Stops setting `tags` on `aws_cur_report_definition.vantage_cost_and_usage_reports` in `main.tf`, keeping tagging only on resources that support it with the current AWS provider constraint.
> 
> This avoids bumping the AWS provider version but **removes tag management for CUR report definitions**, which may produce a plan change for users who previously relied on those tags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50da65fba71706effc27c7eef1bff1234b2142bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->