### PR TITLE
chore: tailor CODEOWNERS for Dependabot (engineering-platform)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
+# Default repository ownership (paths not matched above)
+* @vantage-sh/engineering-persona @vantage-sh/engineering-platform
+
 # Dependabot dependency manifests — @vantage-sh/engineering-platform
 # Tailored from .github/dependabot.yml + repo manifests (ecosystems: github-actions, npm, pre-commit, terraform).
 /.github/workflows/**/* @vantage-sh/engineering-platform
@@ -13,6 +16,3 @@
 /package.json @vantage-sh/engineering-platform
 /pnpm-lock.yaml @vantage-sh/engineering-platform
 /yarn.lock @vantage-sh/engineering-platform
-
-# Default repository ownership (paths not matched above)
-* @vantage-sh/engineering-persona @vantage-sh/engineering-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,18 @@
+# Dependabot dependency manifests — @vantage-sh/engineering-platform
+# Tailored from .github/dependabot.yml + repo manifests (ecosystems: github-actions, npm, pre-commit, terraform).
+/.github/workflows/**/* @vantage-sh/engineering-platform
+/.pre-commit-config.yaml @vantage-sh/engineering-platform
+/.pre-commit-config.yml @vantage-sh/engineering-platform
+/.pre-commit.yaml @vantage-sh/engineering-platform
+/.pre-commit.yml @vantage-sh/engineering-platform
+/.terraform.lock.hcl @vantage-sh/engineering-platform
+/**/*.tf @vantage-sh/engineering-platform
+/**/*.tfvars @vantage-sh/engineering-platform
+/npm-shrinkwrap.json @vantage-sh/engineering-platform
+/package-lock.json @vantage-sh/engineering-platform
+/package.json @vantage-sh/engineering-platform
+/pnpm-lock.yaml @vantage-sh/engineering-platform
+/yarn.lock @vantage-sh/engineering-platform
+
+# Default repository ownership (paths not matched above)
 * @vantage-sh/engineering-persona @vantage-sh/engineering-platform


### PR DESCRIPTION
Assign `@vantage-sh/engineering-platform` as CODEOWNERS for Dependabot-related paths only (from `.github/dependabot.yml` plus repo manifest inference).

- **core**: updates `config/teams/engineering_platform.yml` and regenerated `.github/CODEOWNERS` entries for bundler, npm, docker, and docker-compose; GitHub Actions remain under existing `.github/**/*` ownership.
- **Other repos**: `.github/CODEOWNERS` lists only manifests for the ecosystems this repo uses.

Regenerate across the org later with: `node generate-tailored-dependabot-codeowners.mjs` at the ghorg root (repos other than `core`).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only changes review ownership rules and does not affect runtime code or build behavior.
> 
> **Overview**
> **CODEOWNERS is tailored for Dependabot-related files.** It adds explicit ownership by `@vantage-sh/engineering-platform` for dependency manifest paths (GitHub Actions workflows, pre-commit configs, Terraform files/locks, and npm/yarn/pnpm lockfiles/manifests) while keeping the existing default ownership for everything else.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5734178bc6997751ec63b5eb3c658ed31ff4c96b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Related to PLA-1407