### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 30
+  - package-ecosystem: 'pre-commit'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 30
+  - package-ecosystem: 'terraform'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 30
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 30


### PR DESCRIPTION
Dependabot could be enabled for this repository. Please enable it by merging this pull request so that we can keep our dependencies up to date and secure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds Dependabot configuration only, which may create automated dependency update PRs but does not change runtime code paths.
> 
> **Overview**
> Enables Dependabot by adding `.github/dependabot.yaml` to schedule weekly update checks (with a 30-day cooldown) for `npm`, `pre-commit`, `terraform`, and `github-actions` dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e15bcc589bbfb55b9d3ae7cf650cd172d485dd85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->