### PR TITLE
Add cur_report_enabled parameter to disable creation of CUR report.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ resource "aws_iam_role_policy_attachment" "vantage_cross_account_connection_with
 }
 
 resource "aws_cur_report_definition" "vantage_cost_and_usage_reports" {
-  count                      = var.cur_bucket_name != "" ? 1 : 0
+  count                      = var.cur_bucket_name != "" && var.cur_report_enabled ? 1 : 0
   report_name                = var.cur_report_name
   time_unit                  = var.cur_report_time_unit
   format                     = "textORcsv"

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,12 @@ variable "cur_report_name" {
   default     = "VantageReport"
 }
 
+variable "cur_report_enabled" {
+  type        = bool
+  description = "Enable creation of the CUR report definition. Set to false if you want the S3 bucket but not the aws_cur_report_definition resource (e.g., when using self-managed CUR 2.0 Data Exports instead)."
+  default     = true
+}
+
 variable "compatibility_private_bucket_acl" {
   type        = bool
   description = "For backwards compatibility, users can set this variable to true so a 'private' bucket ACL is applied. This is not necessary for new buckets being created. If you're unsure, leave this as false."


### PR DESCRIPTION
This is needed if you supply your own CUR2 report via aws_bcmdataexports_export resources.

Ideally the module would add aws_bcmdataexports_export, but this can be a follow up PR.