### PR TITLE
ci: Fix skipping commitlint for Dependabot.

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -24,7 +24,7 @@ jobs:
         run: npm ci
 
       - name: Validate PR commits
-        if: github.actor != 'dependabot[bot]'
+        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
   tflint:


### PR DESCRIPTION
Followup to #45 

Use a more accurate way to determine if the PR was authored by dependabot. The `github.actor` approach fails if an end user re-runs the check or triggers it in some way

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow condition change with no runtime or security impact.
> 
> **Overview**
> The **Validate PR commits** commitlint step now skips based on the **pull request author** (`github.event.pull_request.user.login`) instead of **`github.actor`**.
> 
> Dependabot PRs still skip commitlint, but re-runs or manual workflow triggers by someone other than Dependabot no longer incorrectly run commitlint on Dependabot-authored PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbd37feb7533c3411f9340e4ad2737796bef3036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->