### PR TITLE
feat: enforce HTTPS-only on CUR bucket policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Target the module-managed bucket from the Data Export and configure gzip CSV
 output so the existing `.csv.gz` S3 notification delivers report updates to
 Vantage.
 
+When `cur_bucket_name` is set, the bucket policy denies plain-HTTP access by default (`enforce_https_only = true`). AWS billing report delivery is exempt via `aws:PrincipalIsAWSService`. Set `enforce_https_only = false` in the module block to disable the deny statement.
+
 ### Member account
 
 This is an example for creating a member AWS account integration. A cross account IAM role is created for use in gathering cost recommendations, active resources, etc. by Vantage.

--- a/main.tf
+++ b/main.tf
@@ -393,6 +393,39 @@ data "aws_iam_policy_document" "vantage_cur_access" {
       "${aws_s3_bucket.vantage_cost_and_usage_reports[0].arn}/*"
     ]
   }
+
+  dynamic "statement" {
+    for_each = var.enforce_https_only ? [1] : []
+
+    content {
+      sid    = "AllowSSLRequestsOnly"
+      effect = "Deny"
+
+      principals {
+        type        = "*"
+        identifiers = ["*"]
+      }
+
+      actions = ["s3:*"]
+
+      resources = [
+        aws_s3_bucket.vantage_cost_and_usage_reports[0].arn,
+        "${aws_s3_bucket.vantage_cost_and_usage_reports[0].arn}/*",
+      ]
+
+      condition {
+        test     = "Bool"
+        variable = "aws:SecureTransport"
+        values   = ["false"]
+      }
+
+      condition {
+        test     = "BoolIfExists"
+        variable = "aws:PrincipalIsAWSService"
+        values   = ["false"]
+      }
+    }
+  }
 }
 
 resource "vantage_aws_provider" "with_bucket" {

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,12 @@ variable "cur_bucket_lifecycle_days" {
   default     = 200
 }
 
+variable "enforce_https_only" {
+  type        = bool
+  default     = true
+  description = "Deny plain-HTTP S3 requests from non-AWS-service principals on the CUR bucket."
+}
+
 variable "cur_report_time_unit" {
   description = "The granularity of the cost and usage report: HOURLY or DAILY."
   type        = string


### PR DESCRIPTION
## Summary

- Add `enforce_https_only` module variable (default `true`) to deny plain-HTTP S3 requests on the CUR bucket via an `AllowSSLRequestsOnly` policy statement.
- Exempt AWS service principals (`aws:PrincipalIsAWSService` with `BoolIfExists`) so `billingreports.amazonaws.com` and `bcm-data-exports.amazonaws.com` CUR delivery continues to work.
- Document the variable in the README.

## Motivation

Vanta compliance requires S3 buckets to enforce HTTPS. The module owns the only `aws_s3_bucket_policy` for the CUR bucket, so a separate root-level policy would fight the module on every apply.

## Test plan

- [ ] `tflint` passes
- [ ] `terraform fmt` passes
- [ ] Apply with `cur_bucket_name` set and confirm bucket policy contains `AllowSSLRequestsOnly` deny statement
- [ ] Confirm CUR reports still land in the bucket
- [ ] Confirm Vantage cross-account role can still read objects over HTTPS


Made with [Cursor](https://cursor.com)