### PR TITLE
feat: support regional CUR notification topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@ This module handles linking an AWS account with your Vantage account. For root A
 
 This module configures an AWS Account integration on Vantage. By default, it does not configure a CUR integration. If the account is your root AWS account and you want to configure a CUR integration, use the `cur_bucket_name` variable to provision that. The bucket name is used for a private S3 bucket and must be globally unique.
 
-By default, the bucket is provisioned in the `us-east-1` region. If you want to provision the bucket in a different region, use the `cur_bucket_region` variable.
+By default, the bucket is provisioned in the `us-east-1` region. The AWS provider region and `cur_bucket_region` must match so the S3 bucket, CUR definition, and Vantage SNS topic are in the same region.
+
+Vantage supports CUR buckets in the following regions:
+
+- `ap-southeast-1`
+- `eu-west-1`
+- `eu-west-2`
+- `us-east-1`
+- `us-west-2`
 
 The below examples assume you'll use the [assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#assuming-an-iam-role) feature of the AWS provider to access the desired AWS account.
 
@@ -29,9 +37,10 @@ module "vantage-integration" {
 
   # Bucket names must be globally unique. It is provisioned with private acl's
   # and only accessed by Vantage via the provisioned cross account role.
-  cur_bucket_name        = "my-company-cur-vantage"
+  cur_bucket_name   = "my-company-cur-vantage"
+  cur_bucket_region = "us-east-1"
   # Optional: granularity of the CUR report: "HOURLY" or "DAILY"
-  cur_report_time_unit   = "HOURLY"
+  cur_report_time_unit = "HOURLY"
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,14 @@ data "aws_caller_identity" "current" {}
 
 locals {
   account_id = data.aws_caller_identity.current.account_id
+  vantage_sns_topic_arns = {
+    ap-southeast-1 = "arn:aws:sns:ap-southeast-1:630399649041:cost-and-usage-report-uploaded"
+    eu-west-1      = "arn:aws:sns:eu-west-1:630399649041:cost-and-usage-report-uploaded"
+    eu-west-2      = "arn:aws:sns:eu-west-2:630399649041:cost-and-usage-report-uploaded"
+    us-east-1      = "arn:aws:sns:us-east-1:630399649041:cost-and-usage-report-uploaded"
+    us-west-2      = "arn:aws:sns:us-west-2:630399649041:cost-and-usage-report-uploaded"
+  }
+  vantage_sns_topic_arn = var.vantage_sns_topic_arn != null ? var.vantage_sns_topic_arn : local.vantage_sns_topic_arns[var.cur_bucket_region]
 }
 
 data "vantage_aws_provider_info" "default" {
@@ -206,7 +214,7 @@ resource "aws_s3_bucket_notification" "vantage_cost_and_usage_reports" {
   count  = var.cur_bucket_name != "" ? 1 : 0
   bucket = aws_s3_bucket.vantage_cost_and_usage_reports[0].id
   topic {
-    topic_arn     = var.vantage_sns_topic_arn
+    topic_arn     = local.vantage_sns_topic_arn
     events        = ["s3:ObjectCreated:*"]
     filter_suffix = ".csv.gz"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -6,8 +6,19 @@ variable "cur_bucket_name" {
 
 variable "cur_bucket_region" {
   type        = string
-  description = "The region where the CUR bucket will be created."
+  description = "The supported AWS region where the CUR bucket will be created. The AWS provider must use the same region."
   default     = "us-east-1"
+
+  validation {
+    condition = contains([
+      "ap-southeast-1",
+      "eu-west-1",
+      "eu-west-2",
+      "us-east-1",
+      "us-west-2",
+    ], var.cur_bucket_region)
+    error_message = "cur_bucket_region must be one of: ap-southeast-1, eu-west-1, eu-west-2, us-east-1, us-west-2."
+  }
 }
 
 variable "cur_bucket_lifecycle_enabled" {
@@ -35,8 +46,8 @@ variable "cur_report_time_unit" {
 
 variable "vantage_sns_topic_arn" {
   type        = string
-  description = "SNS Topic used to notify of bucket events, such as CUR files being updated. Default is the production SNS topic used by Vantage and should not be changed except for module development."
-  default     = "arn:aws:sns:us-east-1:630399649041:cost-and-usage-report-uploaded"
+  description = "Optional override for the Vantage SNS topic used to notify Vantage of CUR bucket events. This should only be changed for module development."
+  default     = null
 }
 
 variable "cur_report_name" {


### PR DESCRIPTION
## Summary
- select the matching Vantage SNS topic for supported CUR bucket regions
- validate regional support while preserving explicit topic overrides
- document supported regions and the provider-region requirement

## Test plan
- [x] `terraform fmt -check`
- [x] `terraform init -backend=false`
- [x] `terraform validate`
- [x] `tflint`


Made with [Cursor](https://cursor.com)