### PR TITLE
feat: Add configurable CUR bucket lifecycle rules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ module "vantage-integration" {
   cur_bucket_region = "us-east-1"
   # Optional: granularity of the CUR report: "HOURLY" or "DAILY"
   cur_report_time_unit = "HOURLY"
+  # Optional: customize CUR bucket lifecycle (default retains the historical
+  # remove-old-reports / 200-day expiration behavior via the simple settings).
+  # Set to [] to disable lifecycle rules.
+  # cur_bucket_lifecycle_rules = [
+  #   {
+  #     id              = "remove-old-reports"
+  #     expiration_days = 200
+  #     transitions = [
+  #       {
+  #         days          = 30
+  #         storage_class = "STANDARD_IA"
+  #       }
+  #     ]
+  #   }
+  # ]
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ terraform {
       version = ">= 4.0.0"
     }
   }
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.0"
 }
 
 data "aws_caller_identity" "current" {}
@@ -24,6 +24,20 @@ locals {
     us-west-2      = "arn:aws:sns:us-west-2:630399649041:cost-and-usage-report-uploaded"
   }
   vantage_sns_topic_arn = var.vantage_sns_topic_arn != null ? var.vantage_sns_topic_arn : local.vantage_sns_topic_arns[var.cur_bucket_region]
+
+  # Prefer explicit lifecycle rules when set (including [] to disable). Otherwise use
+  # the simple enabled/days settings so existing module callers remain unchanged.
+  cur_bucket_lifecycle_rules = var.cur_bucket_lifecycle_rules != null ? var.cur_bucket_lifecycle_rules : (
+    var.cur_bucket_lifecycle_enabled ? [
+      {
+        id              = "remove-old-reports"
+        enabled         = true
+        prefix          = null
+        expiration_days = var.cur_bucket_lifecycle_days
+        transitions     = []
+      }
+    ] : []
+  )
 }
 
 data "vantage_aws_provider_info" "default" {
@@ -197,19 +211,37 @@ resource "aws_s3_bucket_acl" "vantage_cost_and_usage_reports" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "vantage_cost_and_usage_reports" {
-  count  = var.cur_bucket_name != "" && var.cur_bucket_lifecycle_enabled ? 1 : 0
+  count  = var.cur_bucket_name != "" && length(local.cur_bucket_lifecycle_rules) > 0 ? 1 : 0
   bucket = aws_s3_bucket.vantage_cost_and_usage_reports[0].id
 
-  rule {
-    id = "remove-old-reports"
+  dynamic "rule" {
+    for_each = local.cur_bucket_lifecycle_rules
 
-    filter {}
+    content {
+      id     = rule.value.id
+      status = coalesce(rule.value.enabled, true) ? "Enabled" : "Disabled"
 
-    expiration {
-      days = var.cur_bucket_lifecycle_days
+      filter {
+        prefix = rule.value.prefix != null ? rule.value.prefix : ""
+      }
+
+      dynamic "expiration" {
+        for_each = try(rule.value.expiration_days, null) != null ? [rule.value.expiration_days] : []
+
+        content {
+          days = expiration.value
+        }
+      }
+
+      dynamic "transition" {
+        for_each = try(rule.value.transitions, [])
+
+        content {
+          days          = transition.value.days
+          storage_class = transition.value.storage_class
+        }
+      }
     }
-
-    status = "Enabled"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -21,15 +21,38 @@ variable "cur_bucket_region" {
   }
 }
 
+variable "cur_bucket_lifecycle_rules" {
+  type = list(object({
+    id              = string
+    enabled         = optional(bool, true)
+    prefix          = optional(string)
+    expiration_days = optional(number)
+    transitions = optional(list(object({
+      days          = number
+      storage_class = string
+    })), [])
+  }))
+  description = "Advanced lifecycle rules for the CUR bucket. Set to [] to disable lifecycle configuration. When null, cur_bucket_lifecycle_enabled and cur_bucket_lifecycle_days configure the default rule."
+  default     = null
+
+  validation {
+    condition = var.cur_bucket_lifecycle_rules == null ? true : alltrue([
+      for rule in var.cur_bucket_lifecycle_rules :
+      try(rule.expiration_days, null) != null || length(try(rule.transitions, [])) > 0
+    ])
+    error_message = "Each cur_bucket_lifecycle_rules entry must set expiration_days and/or at least one transition."
+  }
+}
+
 variable "cur_bucket_lifecycle_enabled" {
   type        = bool
-  description = "Enable lifecycle configuration for the CUR bucket."
+  description = "Whether to create the default CUR bucket lifecycle rule when cur_bucket_lifecycle_rules is null."
   default     = true
 }
 
 variable "cur_bucket_lifecycle_days" {
   type        = number
-  description = "Number of days to retain CUR reports in the bucket."
+  description = "Retention period, in days, for the default CUR bucket lifecycle rule when cur_bucket_lifecycle_rules is null."
   default     = 200
 }
 


### PR DESCRIPTION
## Summary
- Adds `cur_bucket_lifecycle_rules` so CUR buckets can use multiple lifecycle rules with expiration and storage-class transitions ([#33](https://github.com/vantage-sh/terraform-aws-vantage-integration/issues/33)).
- Keeps `cur_bucket_lifecycle_enabled` / `cur_bucket_lifecycle_days` as the supported simple configuration path, preserving the historical 200-day default when advanced rules are unset.
- Documents the new variable and bumps the Terraform version floor to `>= 1.3.0` for optional object attributes.

## Test plan
- [x] `terraform fmt -check`
- [x] `terraform init -backend=false`
- [x] `terraform validate`
- [x] Full `terraform plan` in `us-west-2` with the simple default: one enabled `remove-old-reports` rule expiring after 200 days
- [x] Full `terraform plan` in `us-west-2` with a custom expiration and `STANDARD_IA` / `GLACIER` transitions
- [x] Full `terraform plan` in `us-west-2` with `cur_bucket_lifecycle_rules = []`: no lifecycle resource

Closes #33

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes S3 lifecycle behavior for CUR buckets (data retention and cost); misconfiguration could expire or transition objects sooner than intended, though defaults preserve prior behavior.
> 
> **Overview**
> Adds **`cur_bucket_lifecycle_rules`** so the CUR S3 bucket can use multiple lifecycle rules (optional prefix, expiration days, and storage-class transitions), or **`[]`** to omit lifecycle configuration entirely.
> 
> When the new variable is **null**, behavior stays on the existing **`cur_bucket_lifecycle_enabled`** / **`cur_bucket_lifecycle_days`** path (default 200-day `remove-old-reports` rule). **`main.tf`** resolves rules in a local and drives **`aws_s3_bucket_lifecycle_configuration`** with dynamic rules instead of a single hard-coded rule.
> 
> **README** documents the advanced option. The module’s Terraform floor is raised to **`>= 1.3.0`** for optional object attributes on the new variable type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0bd3e6ed17091161e2d620e331dfdb257415b20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


