### PR TITLE
feat: Support self-managed CUR 2.0 exports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ module "vantage-integration" {
 }
 ```
 
+#### Self-managed CUR 2.0 Data Export
+
+To create the bucket and Vantage integration without also creating the legacy
+`aws_cur_report_definition`, disable report creation and manage an
+`aws_bcmdataexports_export` separately:
+
+```hcl
+module "vantage-integration" {
+  source = "vantage-sh/vantage-integration/aws"
+
+  cur_bucket_name    = "my-company-cur-vantage"
+  cur_bucket_region  = "us-east-1"
+  cur_report_enabled = false
+}
+```
+
+Target the module-managed bucket from the Data Export and configure gzip CSV
+output so the existing `.csv.gz` S3 notification delivers report updates to
+Vantage.
+
 ### Member account
 
 This is an example for creating a member AWS account integration. A cross account IAM role is created for use in gathering cost recommendations, active resources, etc. by Vantage.

--- a/main.tf
+++ b/main.tf
@@ -180,7 +180,7 @@ resource "aws_iam_role_policy_attachment" "vantage_cross_account_connection_with
 }
 
 resource "aws_cur_report_definition" "vantage_cost_and_usage_reports" {
-  count                      = var.cur_bucket_name != "" ? 1 : 0
+  count                      = var.cur_bucket_name != "" && var.cur_report_enabled ? 1 : 0
   report_name                = var.cur_report_name
   time_unit                  = var.cur_report_time_unit
   format                     = "textORcsv"

--- a/variables.tf
+++ b/variables.tf
@@ -79,6 +79,12 @@ variable "cur_report_name" {
   default     = "VantageReport"
 }
 
+variable "cur_report_enabled" {
+  type        = bool
+  description = "Whether to create the legacy CUR report definition. Set to false when managing a CUR 2.0 Data Export separately."
+  default     = true
+}
+
 variable "compatibility_private_bucket_acl" {
   type        = bool
   description = "For backwards compatibility, users can set this variable to true so a 'private' bucket ACL is applied. This is not necessary for new buckets being created. If you're unsure, leave this as false."


### PR DESCRIPTION
## Summary
- Add `cur_report_enabled` (default `true`) so callers can retain the module-managed bucket and Vantage integration without creating the legacy CUR definition.
- Document the self-managed `aws_bcmdataexports_export` setup and required gzip CSV output.
- Preserve the existing default behavior and all bucket, IAM, SNS notification, and Vantage provider resources when report creation is disabled.

This supersedes #47 and preserves Stefan Andres's original implementation and authorship.

## Test plan
- [x] `terraform fmt -check -diff`
- [x] `terraform init -backend=false`
- [x] `terraform validate`
- [x] `tflint --init && tflint --format compact`
- [x] Ignored sandbox testbed initialized and validated in account `166127357940`
- [x] Mock-backed plan matrix: default mode creates `aws_cur_report_definition`; disabled mode omits it while retaining bucket, IAM, notification, and Vantage resources
- [x] `commitlint` passes
- [ ] Real Vantage-provider sandbox plan (blocked because `VANTAGE_API_TOKEN` is not available in the agent environment; no token was read or exposed)


Made with [Cursor](https://cursor.com)