### PR TITLE
feat!: Create CUR 2.0 data exports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This module handles linking an AWS account with your Vantage account. For management AWS accounts, use the `cur_bucket_name` variable to provision an Amazon S3 bucket and Cost and Usage Report (CUR) 2.0 data export. Member accounts need cross-account access but do not need their own CUR bucket.
 
-> **Before you begin:** A Vantage API token with **Write** scope, assigned to the **Everyone** team, is required. See [the Vantage documentation](https://docs.vantage.sh/api/authentication) for information on how to create a token. Set the `VANTAGE_API_TOKEN` environment variable (or configure the provider’s `api_token`) before running Terraform.
+> **Before you begin:** A Vantage API token with **Write** scope, assigned to the **Everyone** team, is required. See [the Vantage documentation](https://docs.vantage.sh/api/authentication) for information on how to create a token. Set the `VANTAGE_API_TOKEN` environment variable (or configure the provider’s `api_token`) before running Terraform. This module requires version 5.48.0 or newer of the HashiCorp AWS provider.
 
 ## Usage
 
@@ -80,9 +80,10 @@ output so the existing `.csv.gz` S3 notification delivers report updates to
 Vantage.
 
 When upgrading from a module version that managed a legacy CUR 1.0 report,
-`upgrade_to_cur_2 = true` (the default) replaces `aws_cur_report_definition`
-with `aws_bcmdataexports_export`. Set `upgrade_to_cur_2 = false` to continue
-managing only the legacy CUR 1.0 report.
+remove the `cur_report_additional_schema_elements` input and run
+`terraform init -upgrade`. `upgrade_to_cur_2 = true` (the default) replaces
+`aws_cur_report_definition` with `aws_bcmdataexports_export`. Set
+`upgrade_to_cur_2 = false` to continue managing only the legacy CUR 1.0 report.
 
 When `cur_bucket_name` is set, the bucket policy denies plain-HTTP access by default (`enforce_https_only = true`). AWS billing report delivery is exempt via `aws:PrincipalIsAWSService`. Set `enforce_https_only = false` in the module block to disable the deny statement.
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,10 @@ Target the module-managed bucket from the Data Export and configure gzip CSV
 output so the existing `.csv.gz` S3 notification delivers report updates to
 Vantage.
 
-When upgrading from a module version that managed a legacy CUR 1.0 report, the
-next Terraform apply replaces `aws_cur_report_definition` with
-`aws_bcmdataexports_export`.
+When upgrading from a module version that managed a legacy CUR 1.0 report,
+`upgrade_to_cur_2 = true` (the default) replaces `aws_cur_report_definition`
+with `aws_bcmdataexports_export`. Set `upgrade_to_cur_2 = false` to continue
+managing only the legacy CUR 1.0 report.
 
 When `cur_bucket_name` is set, the bucket policy denies plain-HTTP access by default (`enforce_https_only = true`). AWS billing report delivery is exempt via `aws:PrincipalIsAWSService`. Set `enforce_https_only = false` in the module block to disable the deny statement.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # terraform-vantage-integrations
 
-This module handles linking an AWS account with your Vantage account. For root AWS accounts, you will want to provision a CUR bucket via the `cur_bucket_name` variable. For subaccounts you will want to link access but won't need to configure the CUR bucket.
+This module handles linking an AWS account with your Vantage account. For management AWS accounts, use the `cur_bucket_name` variable to provision an Amazon S3 bucket and Cost and Usage Report (CUR) 2.0 data export. Member accounts need cross-account access but do not need their own CUR bucket.
 
 > **Before you begin:** A Vantage API token with **Write** scope, assigned to the **Everyone** team, is required. See [the Vantage documentation](https://docs.vantage.sh/api/authentication) for information on how to create a token. Set the `VANTAGE_API_TOKEN` environment variable (or configure the provider’s `api_token`) before running Terraform.
 
 ## Usage
 
-This module configures an AWS Account integration on Vantage. By default, it does not configure a CUR integration. If the account is your root AWS account and you want to configure a CUR integration, use the `cur_bucket_name` variable to provision that. The bucket name is used for a private S3 bucket and must be globally unique.
+This module configures an AWS account integration on Vantage. By default, it does not configure a CUR integration. If the account is your management AWS account and you want to configure a CUR integration, use the `cur_bucket_name` variable. The bucket name is used for a private S3 bucket and must be globally unique.
 
-By default, the bucket is provisioned in the `us-east-1` region. The AWS provider region and `cur_bucket_region` must match so the S3 bucket, CUR definition, and Vantage SNS topic are in the same region.
+By default, the bucket is provisioned in the `us-east-1` region. The AWS provider region and `cur_bucket_region` must match so the S3 bucket and Vantage Simple Notification Service (SNS) topic are in the same region.
 
 Vantage supports CUR buckets in the following regions:
 
@@ -20,9 +20,9 @@ Vantage supports CUR buckets in the following regions:
 
 The below examples assume you'll use the [assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#assuming-an-iam-role) feature of the AWS provider to access the desired AWS account.
 
-### Management AWS Account with Cost and Usage Reports (CUR) Integration
+### Management AWS Account with CUR 2.0 Integration
 
-This is an example for creating a management (root) AWS account integration where CUR and an S3 bucket are provisioned in addition to the cross account IAM role. Creating the CUR bucket in your root account is _highly recommended_.
+This example creates a management AWS account integration with a CUR 2.0 data export, S3 bucket, and cross-account Identity and Access Management (IAM) role. Creating the CUR bucket in your management account is _highly recommended_.
 
 ```hcl
 provider "aws" {
@@ -39,7 +39,7 @@ module "vantage-integration" {
   # and only accessed by Vantage via the provisioned cross account role.
   cur_bucket_name   = "my-company-cur-vantage"
   cur_bucket_region = "us-east-1"
-  # Optional: granularity of the CUR report: "HOURLY" or "DAILY"
+  # Optional: granularity of the CUR 2.0 data export: "HOURLY" or "DAILY"
   cur_report_time_unit = "HOURLY"
   # Optional: customize CUR bucket lifecycle (default retains the historical
   # remove-old-reports / 200-day expiration behavior via the simple settings).
@@ -61,8 +61,8 @@ module "vantage-integration" {
 
 #### Self-managed CUR 2.0 Data Export
 
-To create the bucket and Vantage integration without also creating the legacy
-`aws_cur_report_definition`, disable report creation and manage an
+To create the bucket and Vantage integration without also creating the module's
+`aws_bcmdataexports_export`, disable report creation and manage an
 `aws_bcmdataexports_export` separately:
 
 ```hcl
@@ -78,6 +78,10 @@ module "vantage-integration" {
 Target the module-managed bucket from the Data Export and configure gzip CSV
 output so the existing `.csv.gz` S3 notification delivers report updates to
 Vantage.
+
+When upgrading from a module version that managed a legacy CUR 1.0 report, the
+next Terraform apply replaces `aws_cur_report_definition` with
+`aws_bcmdataexports_export`.
 
 When `cur_bucket_name` is set, the bucket policy denies plain-HTTP access by default (`enforce_https_only = true`). AWS billing report delivery is exempt via `aws:PrincipalIsAWSService`. Set `enforce_https_only = false` in the module block to disable the deny statement.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-vantage-integrations
 
-This module handles linking an AWS account with your Vantage account. For management AWS accounts, use the `cur_bucket_name` variable to provision an Amazon S3 bucket and Cost and Usage Report (CUR) 2.0 data export. Member accounts need cross-account access but do not need their own CUR bucket.
+This module handles linking an AWS account with your Vantage account. For management AWS accounts, use the `cur_bucket_name` variable to provision an Amazon S3 bucket and Cost and Usage Report (CUR). Member accounts need cross-account access but do not need their own CUR bucket.
 
 > **Before you begin:** A Vantage API token with **Write** scope, assigned to the **Everyone** team, is required. See [the Vantage documentation](https://docs.vantage.sh/api/authentication) for information on how to create a token. Set the `VANTAGE_API_TOKEN` environment variable (or configure the provider’s `api_token`) before running Terraform. This module requires version 5.48.0 or newer of the HashiCorp AWS provider.
 
@@ -39,6 +39,8 @@ module "vantage-integration" {
   # and only accessed by Vantage via the provisioned cross account role.
   cur_bucket_name   = "my-company-cur-vantage"
   cur_bucket_region = "us-east-1"
+  # Opt in to replacing the legacy CUR 1.0 report with CUR 2.0.
+  upgrade_to_cur_2 = true
   # Optional: granularity of the CUR 2.0 data export: "HOURLY" or "DAILY"
   cur_report_time_unit = "HOURLY"
   # Optional: customize CUR bucket lifecycle (default retains the historical
@@ -81,9 +83,9 @@ Vantage.
 
 When upgrading from a module version that managed a legacy CUR 1.0 report,
 remove the `cur_report_additional_schema_elements` input and run
-`terraform init -upgrade`. `upgrade_to_cur_2 = true` (the default) replaces
-`aws_cur_report_definition` with `aws_bcmdataexports_export`. Set
-`upgrade_to_cur_2 = false` to continue managing only the legacy CUR 1.0 report.
+`terraform init -upgrade`. The module continues managing the legacy report by
+default. Set `upgrade_to_cur_2 = true` to replace `aws_cur_report_definition`
+with `aws_bcmdataexports_export`.
 
 When `cur_bucket_name` is set, the bucket policy denies plain-HTTP access by default (`enforce_https_only = true`). AWS billing report delivery is exempt via `aws:PrincipalIsAWSService`. Set `enforce_https_only = false` in the module block to disable the deny statement.
 

--- a/main.tf
+++ b/main.tf
@@ -6,13 +6,14 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0"
+      version = ">= 5.48.0"
     }
   }
   required_version = ">= 1.3.0"
 }
 
 data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
 
 locals {
   account_id = data.aws_caller_identity.current.account_id
@@ -179,18 +180,49 @@ resource "aws_iam_role_policy_attachment" "vantage_cross_account_connection_with
   policy_arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
 }
 
-resource "aws_cur_report_definition" "vantage_cost_and_usage_reports" {
-  count                      = var.cur_bucket_name != "" && var.cur_report_enabled ? 1 : 0
-  report_name                = var.cur_report_name
-  time_unit                  = var.cur_report_time_unit
-  format                     = "textORcsv"
-  compression                = "GZIP"
-  additional_schema_elements = var.cur_report_additional_schema_elements
-  s3_bucket                  = aws_s3_bucket.vantage_cost_and_usage_reports[0].id
-  s3_region                  = var.cur_bucket_region
-  s3_prefix                  = "${lower(var.cur_report_time_unit)}-v1"
-  report_versioning          = "OVERWRITE_REPORT"
-  refresh_closed_reports     = true
+resource "aws_bcmdataexports_export" "vantage_cost_and_usage_reports" {
+  count = var.cur_bucket_name != "" && var.cur_report_enabled ? 1 : 0
+
+  export {
+    name = var.cur_report_name
+
+    data_query {
+      query_statement = "SELECT bill_bill_type, bill_billing_entity, bill_billing_period_end_date, bill_billing_period_start_date, bill_invoice_id, bill_invoicing_entity, bill_payer_account_id, bill_payer_account_name, cost_category, discount, discount_bundled_discount, discount_total_discount, identity_line_item_id, identity_time_interval, line_item_availability_zone, line_item_blended_cost, line_item_blended_rate, line_item_currency_code, line_item_iam_principal, line_item_legal_entity, line_item_line_item_description, line_item_line_item_type, line_item_net_unblended_cost, line_item_net_unblended_rate, line_item_normalization_factor, line_item_normalized_usage_amount, line_item_operation, line_item_product_code, line_item_resource_id, line_item_tax_type, line_item_unblended_cost, line_item_unblended_rate, line_item_usage_account_id, line_item_usage_account_name, line_item_usage_amount, line_item_usage_end_date, line_item_usage_start_date, line_item_usage_type, pricing_currency, pricing_lease_contract_length, pricing_offering_class, pricing_public_on_demand_cost, pricing_public_on_demand_rate, pricing_purchase_option, pricing_rate_code, pricing_rate_id, pricing_term, pricing_unit, product, product_comment, product_fee_code, product_fee_description, product_from_location, product_from_location_type, product_from_region_code, product_instance_family, product_instance_type, product_instancesku, product_location, product_location_type, product_operation, product_pricing_unit, product_product_family, product_region_code, product_servicecode, product_sku, product_to_location, product_to_location_type, product_to_region_code, product_usagetype, reservation_amortized_upfront_cost_for_usage, reservation_amortized_upfront_fee_for_billing_period, reservation_availability_zone, reservation_effective_cost, reservation_end_time, reservation_modification_status, reservation_net_amortized_upfront_cost_for_usage, reservation_net_amortized_upfront_fee_for_billing_period, reservation_net_effective_cost, reservation_net_recurring_fee_for_usage, reservation_net_unused_amortized_upfront_fee_for_billing_period, reservation_net_unused_recurring_fee, reservation_net_upfront_value, reservation_normalized_units_per_reservation, reservation_number_of_reservations, reservation_recurring_fee_for_usage, reservation_reservation_a_r_n, reservation_start_time, reservation_subscription_id, reservation_total_reserved_normalized_units, reservation_total_reserved_units, reservation_units_per_reservation, reservation_unused_amortized_upfront_fee_for_billing_period, reservation_unused_normalized_unit_quantity, reservation_unused_quantity, reservation_unused_recurring_fee, reservation_upfront_value, resource_tags, savings_plan_amortized_upfront_commitment_for_billing_period, savings_plan_end_time, savings_plan_instance_type_family, savings_plan_net_amortized_upfront_commitment_for_billing_period, savings_plan_net_recurring_commitment_for_billing_period, savings_plan_net_savings_plan_effective_cost, savings_plan_offering_type, savings_plan_payment_option, savings_plan_purchase_term, savings_plan_recurring_commitment_for_billing_period, savings_plan_region, savings_plan_savings_plan_a_r_n, savings_plan_savings_plan_effective_cost, savings_plan_savings_plan_rate, savings_plan_start_time, savings_plan_total_commitment_to_date, savings_plan_used_commitment, tags FROM COST_AND_USAGE_REPORT"
+      table_configurations = {
+        COST_AND_USAGE_REPORT = {
+          BILLING_VIEW_ARN                      = "arn:${data.aws_partition.current.partition}:billing::${local.account_id}:billingview/primary"
+          TIME_GRANULARITY                      = var.cur_report_time_unit
+          INCLUDE_RESOURCES                     = contains(var.cur_report_additional_schema_elements, "RESOURCES") ? "TRUE" : "FALSE"
+          INCLUDE_SPLIT_COST_ALLOCATION_DATA    = "FALSE"
+          INCLUDE_CAPACITY_RESERVATION_DATA     = "FALSE"
+          INCLUDE_IAM_PRINCIPAL_DATA            = "TRUE"
+          INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY = "FALSE"
+        }
+      }
+    }
+
+    destination_configurations {
+      s3_destination {
+        s3_bucket = aws_s3_bucket.vantage_cost_and_usage_reports[0].id
+        s3_prefix = "${lower(var.cur_report_time_unit)}-v2"
+        s3_region = var.cur_bucket_region
+
+        s3_output_configurations {
+          output_type = "CUSTOM"
+          format      = "TEXT_OR_CSV"
+          compression = "GZIP"
+          overwrite   = "OVERWRITE_REPORT"
+        }
+      }
+    }
+
+    refresh_cadence {
+      frequency = "SYNCHRONOUS"
+    }
+  }
+
+  tags = var.tags
+
   depends_on = [
     aws_s3_bucket_policy.vantage_cost_and_usage_reports
   ]

--- a/main.tf
+++ b/main.tf
@@ -221,8 +221,6 @@ resource "aws_bcmdataexports_export" "vantage_cost_and_usage_reports" {
     }
   }
 
-  tags = var.tags
-
   depends_on = [
     aws_s3_bucket_policy.vantage_cost_and_usage_reports
   ]

--- a/main.tf
+++ b/main.tf
@@ -204,7 +204,7 @@ resource "aws_bcmdataexports_export" "vantage_cost_and_usage_reports" {
     destination_configurations {
       s3_destination {
         s3_bucket = aws_s3_bucket.vantage_cost_and_usage_reports[0].id
-        s3_prefix = "${lower(var.cur_report_time_unit)}-v2"
+        s3_prefix = "${lower(var.cur_report_time_unit)}-v1"
         s3_region = var.cur_bucket_region
 
         s3_output_configurations {

--- a/main.tf
+++ b/main.tf
@@ -180,8 +180,26 @@ resource "aws_iam_role_policy_attachment" "vantage_cross_account_connection_with
   policy_arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
 }
 
+resource "aws_cur_report_definition" "vantage_cost_and_usage_reports" {
+  count                      = var.cur_bucket_name != "" && var.cur_report_enabled && !var.upgrade_to_cur_2 ? 1 : 0
+  report_name                = var.cur_report_name
+  time_unit                  = var.cur_report_time_unit
+  format                     = "textORcsv"
+  compression                = "GZIP"
+  additional_schema_elements = ["RESOURCES"]
+  s3_bucket                  = aws_s3_bucket.vantage_cost_and_usage_reports[0].id
+  s3_region                  = var.cur_bucket_region
+  s3_prefix                  = "${lower(var.cur_report_time_unit)}-v1"
+  report_versioning          = "OVERWRITE_REPORT"
+  refresh_closed_reports     = true
+
+  depends_on = [
+    aws_s3_bucket_policy.vantage_cost_and_usage_reports
+  ]
+}
+
 resource "aws_bcmdataexports_export" "vantage_cost_and_usage_reports" {
-  count = var.cur_bucket_name != "" && var.cur_report_enabled ? 1 : 0
+  count = var.cur_bucket_name != "" && var.cur_report_enabled && var.upgrade_to_cur_2 ? 1 : 0
 
   export {
     name = var.cur_report_name

--- a/main.tf
+++ b/main.tf
@@ -192,7 +192,7 @@ resource "aws_bcmdataexports_export" "vantage_cost_and_usage_reports" {
         COST_AND_USAGE_REPORT = {
           BILLING_VIEW_ARN                      = "arn:${data.aws_partition.current.partition}:billing::${local.account_id}:billingview/primary"
           TIME_GRANULARITY                      = var.cur_report_time_unit
-          INCLUDE_RESOURCES                     = contains(var.cur_report_additional_schema_elements, "RESOURCES") ? "TRUE" : "FALSE"
+          INCLUDE_RESOURCES                     = "TRUE"
           INCLUDE_SPLIT_COST_ALLOCATION_DATA    = "FALSE"
           INCLUDE_CAPACITY_RESERVATION_DATA     = "FALSE"
           INCLUDE_IAM_PRINCIPAL_DATA            = "TRUE"

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,13 +4,13 @@ output "vantage_cross_account_connection_role_arn" {
 }
 
 output "vantage_cost_and_usage_report_arn" {
-  description = "The Vantage CUR arn"
-  value       = try(aws_cur_report_definition.vantage_cost_and_usage_reports[0].arn, null)
+  description = "The Vantage CUR 2.0 data export ARN"
+  value       = try(aws_bcmdataexports_export.vantage_cost_and_usage_reports[0].export[0].export_arn, null)
 }
 
 output "vantage_cost_and_usage_report_name" {
-  description = "The Vantage CUR name"
-  value       = try(aws_cur_report_definition.vantage_cost_and_usage_reports[0].report_name, null)
+  description = "The Vantage CUR 2.0 data export name"
+  value       = try(aws_bcmdataexports_export.vantage_cost_and_usage_reports[0].export[0].name, null)
 }
 
 output "vantage_cost_and_usage_reports_bucket_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,13 +4,13 @@ output "vantage_cross_account_connection_role_arn" {
 }
 
 output "vantage_cost_and_usage_report_arn" {
-  description = "The Vantage CUR 2.0 data export ARN"
-  value       = try(aws_bcmdataexports_export.vantage_cost_and_usage_reports[0].export[0].export_arn, null)
+  description = "The Vantage CUR report ARN"
+  value       = try(var.upgrade_to_cur_2 ? aws_bcmdataexports_export.vantage_cost_and_usage_reports[0].export[0].export_arn : aws_cur_report_definition.vantage_cost_and_usage_reports[0].arn, null)
 }
 
 output "vantage_cost_and_usage_report_name" {
-  description = "The Vantage CUR 2.0 data export name"
-  value       = try(aws_bcmdataexports_export.vantage_cost_and_usage_reports[0].export[0].name, null)
+  description = "The Vantage CUR report name"
+  value       = try(var.upgrade_to_cur_2 ? aws_bcmdataexports_export.vantage_cost_and_usage_reports[0].export[0].name : aws_cur_report_definition.vantage_cost_and_usage_reports[0].report_name, null)
 }
 
 output "vantage_cost_and_usage_reports_bucket_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -63,7 +63,7 @@ variable "enforce_https_only" {
 }
 
 variable "cur_report_time_unit" {
-  description = "The granularity of the cost and usage report: HOURLY or DAILY."
+  description = "The granularity of the CUR 2.0 data export: HOURLY or DAILY."
   type        = string
   default     = "DAILY"
 
@@ -81,13 +81,13 @@ variable "vantage_sns_topic_arn" {
 
 variable "cur_report_name" {
   type        = string
-  description = "Report name for the CUR report definition."
+  description = "Name of the CUR 2.0 data export."
   default     = "VantageReport"
 }
 
 variable "cur_report_enabled" {
   type        = bool
-  description = "Whether to create the legacy CUR report definition. Set to false when managing a CUR 2.0 Data Export separately."
+  description = "Whether to create the CUR 2.0 data export. Set to false when managing the data export separately."
   default     = true
 }
 
@@ -134,7 +134,7 @@ variable "tags" {
 }
 
 variable "cur_report_additional_schema_elements" {
-  description = "A list of additional schema elements for the cur report. Only used if a cur bucket is specified."
+  description = "Additional schema elements for the CUR 2.0 data export. Include RESOURCES to export resource IDs."
   type        = list(string)
   default     = ["RESOURCES"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -94,7 +94,7 @@ variable "cur_report_enabled" {
 variable "upgrade_to_cur_2" {
   type        = bool
   description = "Whether to replace the legacy CUR 1.0 report definition with a CUR 2.0 data export."
-  default     = true
+  default     = false
 }
 
 variable "compatibility_private_bucket_acl" {

--- a/variables.tf
+++ b/variables.tf
@@ -63,7 +63,7 @@ variable "enforce_https_only" {
 }
 
 variable "cur_report_time_unit" {
-  description = "The granularity of the CUR 2.0 data export: HOURLY or DAILY."
+  description = "The granularity of the cost and usage report: HOURLY or DAILY."
   type        = string
   default     = "DAILY"
 
@@ -131,12 +131,6 @@ variable "tags" {
   description = "A map of tags to add to all supported resources managed by the module."
   type        = map(string)
   default     = {}
-}
-
-variable "cur_report_additional_schema_elements" {
-  description = "Additional schema elements for the CUR 2.0 data export. Include RESOURCES to export resource IDs."
-  type        = list(string)
-  default     = ["RESOURCES"]
 }
 
 variable "permissions_boundary_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -81,13 +81,19 @@ variable "vantage_sns_topic_arn" {
 
 variable "cur_report_name" {
   type        = string
-  description = "Name of the CUR 2.0 data export."
+  description = "Name of the managed CUR report."
   default     = "VantageReport"
 }
 
 variable "cur_report_enabled" {
   type        = bool
-  description = "Whether to create the CUR 2.0 data export. Set to false when managing the data export separately."
+  description = "Whether to create a CUR report. Set to false when managing the report separately."
+  default     = true
+}
+
+variable "upgrade_to_cur_2" {
+  type        = bool
+  description = "Whether to replace the legacy CUR 1.0 report definition with a CUR 2.0 data export."
   default     = true
 }
 


### PR DESCRIPTION
## Summary

Adds opt-in support for Cost and Usage Report (CUR) 2.0 Billing and Cost Management Data Exports. The new `upgrade_to_cur_2` boolean defaults to `false`, so existing and new module configurations continue managing legacy CUR 1.0 unless callers explicitly enable the migration. CUR 2.0 exports deliver the CUR columns consumed by Vantage as gzip-compressed comma-separated values (CSV), matching the CloudFormation implementation in [core#21131](https://github.com/vantage-sh/core/pull/21131). Related to [PLA-1855](https://linear.app/vantage-sh/issue/PLA-1855/validate-aws-cur-access-and-data).

## Why

The module currently provisions `aws_cur_report_definition`, while Vantage is adding CUR 2.0 support across its onboarding flows. `upgrade_to_cur_2` lets Terraform callers choose when to migrate without changing the default report type or managing both report types simultaneously.

## Changes

- Add `upgrade_to_cur_2`, defaulting to `false`.
- Continue managing `aws_cur_report_definition` by default; manage `aws_bcmdataexports_export` only when `upgrade_to_cur_2 = true`.
- Select the CUR 2.0 columns consumed by Vantage, with resource and Identity and Access Management (IAM) principal data enabled.
- Deliver CUR 2.0 as `TEXT_OR_CSV` with `GZIP` compression, synchronous refresh, and overwrite semantics.
- Preserve the existing `daily-v1` and `hourly-v1` S3 prefixes, bucket notifications, report-name input, output names, and optional self-managed report behavior.
- Return the ARN and name of whichever report type is selected.
- Build the required primary billing view ARN for the current AWS account and partition.
- Require HashiCorp AWS provider 5.48.0 or newer.
- Remove `cur_report_additional_schema_elements`; both managed report paths include resource data.
- Document the opt-in migration and upgrade requirements.

## Design decisions

- The two report resources have mutually exclusive counts, so the module never manages CUR 1.0 and CUR 2.0 simultaneously.
- `upgrade_to_cur_2 = false` preserves existing behavior and the legacy resource's Terraform address. Setting it to `true` removes the managed legacy definition and creates CUR 2.0.
- The CUR 2.0 query lists columns explicitly because AWS Data Exports rejects `SELECT *`; [hashicorp/terraform-provider-aws#37860](https://github.com/hashicorp/terraform-provider-aws/issues/37860) reproduces the `Invalid QueryStatement` response from AWS.
- Split cost allocation, capacity reservation, and manual discount compatibility remain disabled to match the CloudFormation exports. Resource and IAM principal data remain enabled for current Vantage ingestion features.
- The Terraform AWS provider requires `BILLING_VIEW_ARN` in the CUR table configuration. The module selects the current account's primary billing view, preserving the account scope used by the legacy report.
- Existing `daily-v1` and `hourly-v1` prefixes are retained because CUR 2.0 uses its own `data/` and `metadata/` subdirectories and does not require a new outer prefix.
- `cur_report_enabled = false` continues to support creating the module-managed bucket and Vantage connection while managing the report separately.

## Scope

This adds an opt-in CUR 2.0 path for new installations, later CUR attachment, and upgrades from module-managed CUR 1.0. Without `upgrade_to_cur_2 = true`, module-managed report behavior remains legacy CUR 1.0. Role-only integrations without `cur_bucket_name` and callers that manage their own report remain unchanged. The matching CloudFormation changes and converter coverage live in [core#21131](https://github.com/vantage-sh/core/pull/21131).

## Test plan

- [x] `terraform fmt -check`
- [x] `terraform init -upgrade`
- [x] `terraform validate`
- [x] `git diff --check`
- [x] TFLint GitHub Actions check passes.
- [x] Applied the explicit `upgrade_to_cur_2 = true` path from `vantage-terraform-test` against the development AWS account.
- [x] Confirmed `VantageReport` is `HEALTHY` in AWS Billing and Cost Management Data Exports.
- [x] Confirmed the export uses the primary billing view, daily granularity, resource and IAM principal data, and disables split cost allocation, capacity reservation, and manual discount compatibility.
- [x] Confirmed delivery targets the expected S3 bucket and `daily-v1` prefix using custom text/CSV output, GZIP compression, overwrite semantics, and synchronous refresh.
- [x] Confirmed the default `upgrade_to_cur_2 = false` path plans only the legacy report and removes the CUR 2.0 export.
- [x] Confirmed the first CUR 2.0 `.csv.gz` delivery and manifest appear in Amazon S3.
- [x] Confirm Vantage imports the delivery successfully and costs, resource IDs, and provider tags appear correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billing report provisioning and AWS provider constraints. Default stays CUR 1.0, but enabling the flag replaces the managed report resource.
> 
> **Overview**
> Adds **opt-in CUR 2.0** via `upgrade_to_cur_2` (default `false`). Existing configs keep managing `aws_cur_report_definition`; setting the flag replaces it with `aws_bcmdataexports_export` (never both).
> 
> The CUR 2.0 export uses gzip CSV, overwrite + synchronous refresh, the same `hourly-v1`/`daily-v1` prefixes, resource + IAM principal columns, and the account’s primary billing view. Report ARN/name outputs follow whichever type is selected.
> 
> Requires AWS provider **>= 5.48.0**. Removes `cur_report_additional_schema_elements` (resources are always included). Callers using that input must drop it and `terraform init -upgrade`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fb1be57c6654b14106f7b850063c261021f8e68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->