### PR TITLE
feat: Allow retaining legacy CUR reports

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -180,6 +180,24 @@ resource "aws_iam_role_policy_attachment" "vantage_cross_account_connection_with
   policy_arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
 }
 
+resource "aws_cur_report_definition" "vantage_cost_and_usage_reports" {
+  count                      = var.cur_bucket_name != "" && var.cur_report_enabled && !var.delete_legacy_cur_report ? 1 : 0
+  report_name                = var.cur_report_name
+  time_unit                  = var.cur_report_time_unit
+  format                     = "textORcsv"
+  compression                = "GZIP"
+  additional_schema_elements = ["RESOURCES"]
+  s3_bucket                  = aws_s3_bucket.vantage_cost_and_usage_reports[0].id
+  s3_region                  = var.cur_bucket_region
+  s3_prefix                  = "${lower(var.cur_report_time_unit)}-v1"
+  report_versioning          = "OVERWRITE_REPORT"
+  refresh_closed_reports     = true
+
+  depends_on = [
+    aws_s3_bucket_policy.vantage_cost_and_usage_reports
+  ]
+}
+
 resource "aws_bcmdataexports_export" "vantage_cost_and_usage_reports" {
   count = var.cur_bucket_name != "" && var.cur_report_enabled ? 1 : 0
 

--- a/variables.tf
+++ b/variables.tf
@@ -91,6 +91,12 @@ variable "cur_report_enabled" {
   default     = true
 }
 
+variable "delete_legacy_cur_report" {
+  type        = bool
+  description = "Whether to delete the legacy CUR 1.0 report definition when creating the CUR 2.0 data export."
+  default     = true
+}
+
 variable "compatibility_private_bucket_acl" {
   type        = bool
   description = "For backwards compatibility, users can set this variable to true so a 'private' bucket ACL is applied. This is not necessary for new buckets being created. If you're unsure, leave this as false."


### PR DESCRIPTION
## Summary

- Add `delete_legacy_cur_report`, a boolean input that defaults to `true` so the behavior in [#77](https://github.com/vantage-sh/terraform-aws-vantage-integration/pull/77) remains unchanged.
- When set to `false`, keep managing the existing CUR 1.0 report definition while creating the CUR 2.0 Data Export.
- Leave outputs and all other CUR 2.0 behavior unchanged.

This PR is stacked on #77 and is optional follow-up work.

## Test plan

- [x] `terraform fmt -check`
- [x] `terraform init -backend=false`
- [x] `terraform validate`
- [x] `git diff --check`
- [ ] Confirm an upgrade with `delete_legacy_cur_report = false` plans the CUR 2.0 export without destroying the existing CUR 1.0 definition.

Made with [Cursor](https://cursor.com)